### PR TITLE
fix(auth): add dedicated login throttle to harden against brute-force

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Accumulating since `[1.0.0]` (2026-04-16). Production at `https://emelmujiro.com
 - urllib3 2.6.3 → 2.7.0: patched CVE-2026-44431 (information disclosure via cross-origin redirects forwarding sensitive headers) and CVE-2026-44432 (DoS from excessive HTTP response decompression); Trivy HIGH-severity gate was blocking every PR Security Scan (`a7a2cc6`)
 - pyjwt 2.12.1 → 2.13.0: patched CVE-2026-48526 (authentication bypass via forged JSON Web Tokens), a `djangorestframework-simplejwt` transitive bumped in `uv.lock` only (simplejwt pins `pyjwt>=1.7.1`); Trivy HIGH gate (`046b2cff`)
 - form-data 4.0.5 → 4.0.6: patched CVE-2026-12143 (CRLF injection via unescaped multipart field/file names), an axios transitive pinned via root + frontend `^4.0.6` override (axios accepts `^4.0.5`); Trivy HIGH gate (`046b2cff`)
+- Dedicated brute-force throttle on the login endpoint: new `LoginRateThrottle` (`scope = "login"`, `10/hour` per IP) replaces reliance on the global `anon` rate (`100/hour`). `POST /api/auth/login/` previously allowed 100 password guesses per IP per hour against the single admin account with no account lockout; the new scope tightens that to 10, matching the priority of the `contact` (5/hour) and `newsletter` (3/hour) scopes. Regression test asserts the 11th attempt returns 429
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ graph LR
 - **Performance** — Vendor chunk splitting, Lighthouse CI assertions, < 10MB bundle budget
 - **Security** — DOMPurify HTML sanitization, CI `${{ }}` injection prevention, uuid4 uploads, rate limiting, IP blocking
 - **Privacy Policy** — 13-section bilingual page compliant with Korean PIPA Article 30
-- **Tests** — Vitest (1218 tests) + Django unittest (360 tests) + Playwright E2E (5 profiles)
+- **Tests** — Vitest (1218 tests) + Django unittest (361 tests) + Playwright E2E (5 profiles)
 - **CI/CD** — GitHub Actions: lint, type-check, test, Trivy security scan, bundle size, Lighthouse, Codecov, auto-deploy via webhook
 
 ## License

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -85,8 +85,15 @@ def register(request):
     return response
 
 
+class LoginRateThrottle(AnonRateThrottle):
+    """Dedicated brute-force throttle for the login endpoint (per-IP)."""
+
+    scope = "login"
+
+
 @api_view(["POST"])
 @permission_classes([AllowAny])
+@throttle_classes([LoginRateThrottle])
 def login(request):
     """
     User login endpoint

--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -4294,3 +4294,29 @@ class UrlsDebugBranchTestCase(TestCase):
 
         # Reload with original settings to avoid side effects
         importlib.reload(urls_module)
+
+
+class LoginThrottleTestCase(APITestCase):
+    """LoginRateThrottle caps login attempts at the 'login' scope rate (10/hour)."""
+
+    def setUp(self):
+        from django.core.cache import cache
+
+        cache.clear()
+        User.objects.create_user(username="throttleuser", email="throttle@example.com", password="testpass12345")
+
+    def tearDown(self):
+        from django.core.cache import cache
+
+        cache.clear()
+
+    def test_login_throttled_after_rate_exceeded(self):
+        """The 11th login attempt from one IP within the hour returns 429."""
+        url = reverse("login")
+        data = {"username": "throttleuser", "password": "wrongpassword"}
+        statuses = [
+            self.client.post(url, data, format="json", REMOTE_ADDR="203.0.113.7").status_code for _ in range(11)
+        ]
+        # First 10 are processed (401 invalid creds), the 11th is throttled.
+        self.assertEqual(statuses[9], status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(statuses[10], status.HTTP_429_TOO_MANY_REQUESTS)

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -278,6 +278,7 @@ REST_FRAMEWORK = {
     "DEFAULT_THROTTLE_RATES": {
         "anon": "100/hour",
         "user": "1000/hour",
+        "login": "10/hour",
         "contact": "5/hour",
         "newsletter": "3/hour",
         "admin": "120/hour",


### PR DESCRIPTION
## Summary

Hardens the login endpoint against brute-force, the top finding from a `/cso` security audit.

`POST /api/auth/login/` previously relied on the global `anon` throttle (`100/hour`) with **no account lockout** — allowing 100 password guesses per IP per hour against the single admin account. `register` had an explicit throttle but `login` did not.

**Change:** new `LoginRateThrottle` (`scope = "login"`, `10/hour` per IP) attached to the login view, matching the priority of the existing `contact` (5/hour) and `newsletter` (3/hour) scopes. Follows the existing `ContactRateThrottle(AnonRateThrottle)` pattern.

- `backend/api/auth.py` — `LoginRateThrottle` class + `@throttle_classes([LoginRateThrottle])` on `login`
- `backend/config/settings.py` — `"login": "10/hour"` added to `DEFAULT_THROTTLE_RATES`
- `backend/api/tests.py` — `LoginThrottleTestCase` regression test (isolated IP + cache clear)

## Test Coverage

New code path (login throttle) is covered by `LoginThrottleTestCase.test_login_throttled_after_rate_exceeded`: 10 attempts return 401, the 11th returns 429.

Backend tests: 360 → 361 (+1). All pass. `black` + `flake8` clean.

## Pre-Landing Review

Inline review — one informational note: `@throttle_classes` applies even in `DEBUG` (where the global throttle is disabled), so local dev login is capped at 10/hour. This matches the existing `register` precedent (already throttled in DEBUG via explicit `@throttle_classes`), so it is consistent with current conventions. Not blocking.

## Notes

- VERSION not bumped — this project accumulates changes under CHANGELOG `## [Unreleased]` and cuts releases separately (VERSION has stayed `1.0.0` across prior merges). Entry added under `### Security`.
- A second `/cso` finding (unused public `/api/auth/register/` endpoint) is deferred pending a decision on whether signup is planned.

## Test plan
- [x] `DATABASE_URL="" uv run python manage.py test api.tests` — 361 passed
- [x] `LoginThrottleTestCase` — 10×401 then 429
- [x] `black` + `flake8` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)