### PR TITLE
feat(deploy): assert live backend commit to catch stale deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Accumulating since `[1.0.0]` (2026-04-16). Production at `https://emelmujiro.com
 
 ### Added
 
+- Deploy verification: `/api/health/` now returns the running backend's git `commit` (baked into the image via a `GIT_COMMIT` build arg → image `ENV` → `settings.GIT_COMMIT`). `auto-deploy.sh` asserts the live backend reports the just-pulled `HEAD` and fails the deploy if it doesn't — closing the gap where a stale/failed backend build passed the bare `200` health check (the exact masking that hid the credsStore build failures). Defaults to `unknown` outside a built container (tests, local dev)
 - 3 teaching-history entries for 2026: 한국환경산업기술원(KEITI) AI에코혁신랩 (LLM·RAG, surfaced immediately as the class starts 2026-06-09), plus two pre-scheduled (hidden until their start date via `visibleAfter`) — 이화여자대학교 생성형 AI 엑셀 자동화 (`2026-06-23`) and 과학기술연합대학원대학교(UST) 고급 연구방법론 (`2026-07-08`). New i18n keys 41/42. Entry count 39 → 41 active (`69da502`, `ae50f21`, `de618d5`). Two one-shot remote routines re-run the deploy on 06-23 / 07-08 so the SSG prerender snapshot picks the gated entries up for crawlers
 - Two-device sync helpers: `.private/` rsync via `scripts/sync_private.sh`, MBP/Mac mini divergence detector via `scripts/check_machine_sync.sh` — caught a silent 16-commit production drift incident retroactively (`0f84140`)
 - `npm run check:css` script for detecting CSS classes shipped in build but never referenced in `src/` (`0560f32`)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -25,6 +25,13 @@ RUN uv sync --frozen --no-dev
 # Copy project
 COPY . .
 
+# Bake the deployed git commit into the image so /api/health/ can report exactly
+# which code is running. Placed after COPY . . so it only invalidates this final
+# cheap layer (not the dep install). Lets auto-deploy.sh assert the live backend
+# matches the pulled HEAD instead of trusting a bare 200 from a stale container.
+ARG GIT_COMMIT=unknown
+ENV GIT_COMMIT=$GIT_COMMIT
+
 # Create non-root user and data directory for SQLite
 RUN adduser --disabled-password --gecos '' appuser && \
     mkdir -p /app/data /app/logs && \

--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -1063,6 +1063,9 @@ class HealthCheckAPITestCase(APITestCase):
         assert response.data is not None
         self.assertEqual(response.data["status"], "healthy")
         self.assertIn("timestamp", response.data)
+        # Deployed commit is baked into the image at build time; defaults to
+        # "unknown" outside a built container (tests, local dev).
+        self.assertIn("commit", response.data)
 
 
 @override_settings(REST_FRAMEWORK={**NO_THROTTLE})

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -621,7 +621,7 @@ class NewsletterView(APIView):
 @throttle_classes([])
 def health_check(request):
     """Server health check (no throttle — called by Docker healthcheck every 30s)"""
-    return Response({"status": "healthy", "timestamp": timezone.now()})
+    return Response({"status": "healthy", "timestamp": timezone.now(), "commit": settings.GIT_COMMIT})
 
 
 @api_view(["GET"])

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -13,6 +13,11 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DEBUG", "False").lower() == "true"
 
+# Deployed git commit, baked into the image at build time (see backend/Dockerfile).
+# Surfaced by /api/health/ so the deploy script can assert the live backend runs
+# the pulled code instead of trusting a 200 from a stale container.
+GIT_COMMIT = os.environ.get("GIT_COMMIT", "unknown")
+
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.environ.get("SECRET_KEY")
 if not SECRET_KEY:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       dockerfile: Dockerfile
       cache_from:
         - emelmujiro/backend:latest
+      args:
+        GIT_COMMIT: ${GIT_COMMIT:-unknown}
     image: emelmujiro/backend:${TAG:-latest}
     container_name: emelmujiro-backend
     restart: unless-stopped

--- a/scripts/auto-deploy.sh
+++ b/scripts/auto-deploy.sh
@@ -105,6 +105,11 @@ VITE_API_URL="${VITE_API_URL:-https://api.emelmujiro.com/api}" npm run build
 # Ensure all services are running
 echo "$LOG_PREFIX Starting services..."
 cd "$REPO_DIR"
+# Bake the just-pulled commit into the backend image (compose build arg → image
+# ENV → /api/health/). Asserted post-deploy so a no-op/failed backend build can't
+# masquerade as success via a 200 from the stale container.
+GIT_COMMIT=$(git rev-parse HEAD)
+export GIT_COMMIT
 docker compose up -d --build backend
 if [ "$NGINX_CONF_CHANGED" = true ]; then
   # Validate the new nginx.conf before applying it, so a syntax error aborts the
@@ -156,6 +161,20 @@ if [ "$backend_ok" = false ] || [ "$frontend_ok" = false ]; then
   [ "$frontend_ok" = false ] && echo "$LOG_PREFIX ERROR: Frontend health check did not pass within 60s"
   echo "$LOG_PREFIX Deploy failed: service(s) not healthy"
   exit 1
+fi
+
+# A 200 from /api/health/ only proves *a* backend is up — it passes against a
+# stale container too (exactly what masked the silent backend-deploy failure).
+# Assert the live backend reports the commit we just deployed.
+LIVE_COMMIT=$(curl -sf http://127.0.0.1:8000/api/health/ 2>/dev/null | sed -n 's/.*"commit"[ ]*:[ ]*"\([^"]*\)".*/\1/p')
+if [ "$LIVE_COMMIT" = "unknown" ] || [ -z "$LIVE_COMMIT" ]; then
+  echo "$LOG_PREFIX WARNING: backend reports commit='$LIVE_COMMIT' (image built without GIT_COMMIT?) — cannot verify deployed code"
+elif [ "$LIVE_COMMIT" != "$GIT_COMMIT" ]; then
+  echo "$LOG_PREFIX ERROR: backend is running commit $LIVE_COMMIT but HEAD is $GIT_COMMIT — backend image did NOT rebuild"
+  echo "$LOG_PREFIX Deploy failed: stale backend"
+  exit 1
+else
+  echo "$LOG_PREFIX Backend verified running deployed commit ${GIT_COMMIT:0:8}"
 fi
 
 echo "$LOG_PREFIX Deploy completed at $(date)"


### PR DESCRIPTION
## Summary

The follow-up hardening for the silent-stale-backend bug. The deploy health check only required a `200` from `/api/health/` — which a stale container answers exactly like a fresh one. That masking is what let the credsStore build failures (#343/#344) ship stale backend code while every signal stayed green.

This bakes the deployed commit into the image and asserts it post-deploy, so a no-op or failed backend build can no longer pass.

## Changes
- `backend/Dockerfile` — `ARG GIT_COMMIT` → `ENV GIT_COMMIT` (after `COPY . .`, so it only invalidates the final cheap layer)
- `docker-compose.yml` — backend `build.args.GIT_COMMIT: ${GIT_COMMIT:-unknown}`
- `backend/config/settings.py` — `GIT_COMMIT = os.environ.get("GIT_COMMIT", "unknown")`
- `backend/api/views.py` — `/api/health/` returns `"commit": settings.GIT_COMMIT`
- `scripts/auto-deploy.sh` — exports `GIT_COMMIT=$(git rev-parse HEAD)` before the build; after health passes, asserts the live backend reports that commit (mismatch → `exit 1`; `unknown`/empty → warning, not fatal, for backwards compat)
- `backend/api/tests.py` — health test asserts the `commit` field is present

## Why `unknown` is non-fatal
Images built without the arg (local `docker build`, older images) report `unknown`; the script warns rather than failing so it degrades gracefully. A real mismatch (old commit vs HEAD) is the hard failure.

## Verification
- [x] `bash -n scripts/auto-deploy.sh` — OK; commit-parse `sed` validated against sample health JSON
- [x] Backend suite: `Ran 355 tests OK`; `black` + `flake8` clean
- [ ] **End-to-end via webhook post-merge** — this is the first real backend change through the now-fixed pipeline, so the deploy will both prove the pipeline AND exercise the new assertion (`Backend verified running deployed commit <sha>` in the log). I'll confirm before declaring done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)