### PR TITLE
fix(deps): sync lockfile with jest-dom 7 so npm ci works again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "@lhci/cli": "^0.15.1",
         "@playwright/test": "^1.61.0",
         "@testing-library/dom": "^10.4.1",
-        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^26.1.1",
         "@types/react": "^19.2.14",
@@ -2708,9 +2708,9 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
-      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2722,9 +2722,12 @@
         "redent": "^3.0.0"
       },
       "engines": {
-        "node": ">=14",
+        "node": ">=22",
         "npm": ">=6",
         "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11"
       }
     },
     "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {


### PR DESCRIPTION
**Deploys are currently blocked on main.** This unblocks them.

## What broke

Merging #380 landed the `package.json` bump to `@testing-library/jest-dom@^7.0.0` but left `package-lock.json` resolving `6.9.1`. `npm ci` rejects that combination outright:

```
$ npm ci --prefer-offline --no-audit
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json or npm-shrinkwrap.json are in sync.
$ echo $?
1
```

`scripts/auto-deploy.sh:67` runs `npm ci` under `set -euo pipefail`, so the deploy aborted there — before the build, before the backend recreate.

## How it surfaced

Not from CI. The `Main CI/CD Pipeline` run for #380 is **green**, because `deploy-webhook.js` returns `200` on trigger-accept rather than deploy-success (Gotcha #17).

It surfaced from the health endpoint's commit assertion, which is exactly what Gotcha #17 added it for:

```
$ curl -s https://emelmujiro.com/api/health/ | jq -r .commit
c9a32b1b        ← #379, the previous merge
$ git log --oneline -1
4391a43c        ← #380
```

The site stayed up on the previous build the whole time — `frontend/build` is a bind mount and was never touched — but every subsequent deploy would have failed the same way.

## Fix

Lockfile regenerated so both agree on `7.0.0`. `npm ci` now exits `0`, and per Gotcha #13 the binding count is unchanged:

```
$ grep -c 'node_modules/@rolldown/binding-' package-lock.json
15
```

jest-dom 7 itself was verified before #380 was merged: 1228 vitest tests pass, `tsc` clean, `@testing-library/dom@^10.4.1` already declared so v7's new required peer is satisfied, and Gotcha #4 still holds (`tsconfig.build.json` `types` stays `["vite/client","node"]`).

## Why the drift happened, and what to watch for

#380's branch predated #392, which had also touched `package-lock.json`. The squash merge applied dependabot's `package.json` hunk while its lockfile hunk did not carry the resolved-version change across, leaving the two inconsistent. Nothing in CI catches this: the frontend jobs run `npm install`, not `npm ci`, so only the Mac mini deploy hits it.

Worth considering as a follow-up (not folded in here): have a CI job run `npm ci` so lockfile drift fails a PR instead of a deploy. That is a workflow change with its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)