### PR TITLE
ci: accept perf and deps-dev commit types

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -105,7 +105,8 @@ jobs:
             if [[ "$msg" =~ ^Bump\ |^build\(deps|^chore\(deps|^ci\(deps|^deps-dev\(deps|^deps\(deps ]]; then
               continue
             fi
-            if [[ ! "$msg" =~ ^(feat|fix|docs|style|refactor|test|chore|deps|ci)(\(.+\))?: ]]; then
+            # deps-dev precedes deps so the longer type wins the alternation.
+            if [[ ! "$msg" =~ ^(feat|fix|docs|style|refactor|test|chore|perf|deps-dev|deps|ci)(\(.+\))?: ]]; then
               echo "Invalid commit message: $msg"
               echo "Please use conventional commits format: type(scope): description"
               exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ Build, runtime, and infrastructure rules. Violating these breaks deploys, securi
 
 ## Code Conventions
 
-- **Conventional commits** required (English only): `type(scope): description`. Types: `feat fix docs style refactor test chore deps ci`.
+- **Conventional commits** required (English only): `type(scope): description`. Types: `feat fix docs style refactor test chore perf deps deps-dev ci` (the exact set the `pr-checks.yml` regex accepts — keep the two in sync). `deps-dev` exists because dependabot writes `deps-dev(deps-dev):` and the skip pattern exempts it, so a human finishing one of its PRs by hand needs the same type available.
 - **Branch naming**: `feature/name` or `fix/description`.
 - **ESLint flat config** (`eslint.config.mjs`, NOT `.eslintrc`). Zero-warnings is the **target**, not yet a hard gate (`lint` script lacks `--max-warnings=0`).
 - **English comments only**.


### PR DESCRIPTION
Follow-up to #410. The commit-message check in `pr-checks.yml` rejected a commit type the repo's own history is full of.

## What's wrong

`pr-checks.yml:108` allowed `feat|fix|docs|style|refactor|test|chore|deps|ci`. Two gaps:

**`deps-dev`** — dependabot writes `deps-dev(deps-dev):`, and the skip pattern one line above exempts it, so 47 such subjects are on `main`. But the validation regex never learned the type, so a human writing `deps-dev:` gets rejected. That is exactly what happened in #410: dependabot shipped #402 with `frontend/package.json` but no lockfile, `npm ci` failed with `EUSAGE` on every job, the bump had to be redone locally — and the resulting commit was rejected for using dependabot's own vocabulary.

**`perf`** — 6 subjects on `main` (`perf(sentry)`, `perf(prerender)`, `perf(frontend)`, `perf(insights)`, `perf(lighthouse)`, `perf(analytics)`). None of them arrived via a PR; all were direct pushes to `main`, which this repo allows by design. So the check never evaluated them and the gap stayed latent until a `perf` change happened to come through a PR. `perf` is also part of the user-level commit convention.

`deps-dev` is placed before `deps` in the alternation so the longer type wins the match.

## Verification

Ran the workflow's exact three conditions over real and adversarial subjects:

| subject | result |
|---|---|
| `deps-dev: bump jsdom to 30.0.1` | ACCEPT (was REJECT) |
| `perf(sentry): lazy-load via re-export shim` | ACCEPT (was REJECT) |
| `deps: align all @tiptap/* to 3.29.2` | ACCEPT |
| `fix(nginx): keep https on directory paths` | ACCEPT |
| `deps-dev(deps-dev): bump the dev-dependencies group` | SKIP (bot) |
| `deps(deps): bump web-vitals from 5.3.0 to 6.0.1` | SKIP (bot) |
| `depsfoo: not a real type` | REJECT |
| `random subject with no type` | REJECT |

`depsfoo:` still rejecting confirms the widened alternation did not turn into a prefix match. YAML parses clean.

## Deliberately not included

`security:` and `merge:` each appear once on `main` and would still be rejected. Both were direct pushes, both have a conventional equivalent (`fix(security):`, and a real merge commit hits the `^Merge` skip). Adding one-off types to buy retroactive validity would weaken the check for no future benefit.

`CLAUDE.md`'s type list is updated to the exact accepted set, with a note that the two must stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)