### PR TITLE
docs: record the commit-msg hook and ASCII rule in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Cross-project behavioral guidelines (Think before coding · Simplicity first · 
 
 This root file holds the always-loaded, cross-cutting rules. Domain specifics live in `.claude/rules/` and auto-load when Claude reads matching files: `frontend.md` (Architecture, UI Conventions, Testing — paths `frontend/**`), `backend.md` (constants, utilities, backend test output — paths `backend/**`).
 
-**Size**: the 2026-06 restructure set a `< 200 lines / 25 KB` target. Currently 33.9 KB / 184 lines — lines within, bytes over. Anthropic's guidance is explicit that a bloated CLAUDE.md gets its rules _ignored_, so the overage is a real cost, not a cosmetic one. **The lever is compressing wording in place, not relocating entries.** Splitting the 8 dependency Gotchas into a path-scoped `.claude/rules/dependencies.md` was tried on 2026-07-31 and reverted, for two reasons worth not rediscovering: (1) markdown auto-renumbers ordered lists, so the Gotcha IDs — cited from commits, CHANGELOG and PRs — silently shifted and every in-file `Gotcha #N` cross-reference broke; (2) these rules are triggered by _situations_ (a red security scan, a dependabot PR, a Vitest crash), not by reading `package.json`, so a path-scoped trigger would mostly fail to fire. Path-scoping works for `frontend.md`/`backend.md` because those genuinely key on file reads.
+**Size**: the 2026-06 restructure set a `< 200 lines / 25 KB` target. Currently 34.1 KB / 184 lines — lines within, bytes over. Anthropic's guidance is explicit that a bloated CLAUDE.md gets its rules _ignored_, so the overage is a real cost, not a cosmetic one. **The lever is compressing wording in place, not relocating entries.** Splitting the 8 dependency Gotchas into a path-scoped `.claude/rules/dependencies.md` was tried on 2026-07-31 and reverted, for two reasons worth not rediscovering: (1) markdown auto-renumbers ordered lists, so the Gotcha IDs — cited from commits, CHANGELOG and PRs — silently shifted and every in-file `Gotcha #N` cross-reference broke; (2) these rules are triggered by _situations_ (a red security scan, a dependabot PR, a Vitest crash), not by reading `package.json`, so a path-scoped trigger would mostly fail to fire. Path-scoping works for `frontend.md`/`backend.md` because those genuinely key on file reads.
 
 By task type:
 
@@ -27,7 +27,7 @@ Full-stack monorepo (React 19 + Django 6) deployed on Mac Mini via Docker + Clou
 - **Frontend**: http://localhost:5173 (Vite, NOT port 3000). Build output: `build/` (NOT `dist/`). Import alias `@` → `src/`
 - **Backend**: http://localhost:8000. Single app: `api/`. Uses **uv** (NOT pip)
 - **Dev proxy**: Vite proxies `/api` → `http://127.0.0.1:8000` (no CORS issues in dev)
-- **Node ≥ 24**, **Python 3.12** required. Husky pre-commit runs lint-staged automatically
+- **Node ≥ 24**, **Python 3.12** required. Husky runs lint-staged on `pre-commit` and `scripts/check-commit-msg.sh` on `commit-msg`
 
 > Design rationale in `.private/strategy.md`; session log + opsec notes in `.private/journal.md`; secret setup in `.private/secrets-setup.md`. All gitignored, maintainer-local (synced via `scripts/sync_private.sh`). Past git history (pre-`01c4db8`) retains earlier strategy versions.
 
@@ -114,7 +114,7 @@ Build, runtime, and infrastructure rules. Violating these breaks deploys, securi
 
 ## Code Conventions
 
-- **Conventional commits** required (English only): `type(scope): description`. Types: `feat fix docs style refactor test chore perf deps-dev deps ci`. **`scripts/check-commit-msg.sh` is the single source of truth** — the `.husky/commit-msg` hook and the `pr-checks.yml` step both call it, so edit the type list there and never re-inline the regex in a caller. `deps-dev` exists because dependabot writes `deps-dev(deps-dev):` and the skip pattern exempts it, so a human finishing one of its PRs by hand needs the same type available. Exempt: merge commits, `fixup!`/`squash!`/`amend!` (autosquash rewrites them away), `Revert "…"`, and dependabot's formats.
+- **Conventional commits** required (English only): `type(scope): description`. Types: `feat fix docs style refactor test chore perf deps-dev deps ci`. **`scripts/check-commit-msg.sh` is the single source of truth** — the `.husky/commit-msg` hook and the `pr-checks.yml` step both call it, so edit the type list there and never re-inline the regex in a caller. `deps-dev` exists because dependabot writes `deps-dev(deps-dev):` and the skip pattern exempts it, so a human finishing one of its PRs by hand needs the same type available. Exempt: merge commits, `fixup!`/`squash!`/`amend!` (autosquash rewrites them away), `Revert "…"`, and dependabot's formats. English-only is machine-enforced as ASCII on the **subject line only** — the body is not inspected — so `git commit --no-verify` is the escape for a subject that genuinely needs a non-ASCII proper noun.
 - **Branch naming**: `feature/name` or `fix/description`.
 - **ESLint flat config** (`eslint.config.mjs`, NOT `.eslintrc`). Zero-warnings is the **target**, not yet a hard gate (`lint` script lacks `--max-warnings=0`).
 - **English comments only**.


### PR DESCRIPTION
Third pass over the docs, this time asking not "is any claim false?" but "does the source-of-truth file still describe what the code does?" Two gaps, both left by my own #414 and #417.

## 1. Project Overview knew about one hook

> Husky pre-commit runs lint-staged automatically

There are two hooks since #414. Nothing here was false, but a reader learned about `pre-commit` and would not know a `commit-msg` hook exists until it rejected their commit.

## 2. The ASCII rule and its escape lived only in CONTRIBUTING.md

The commit-convention entry named the hook and `scripts/check-commit-msg.sh`, but not that English-only is now machine-enforced as ASCII, nor that `--no-verify` is the sanctioned escape, nor that only the **subject line** is inspected.

That matters structurally, not just for completeness: CONTRIBUTING.md says *"for the 'why' behind any rule, look there [CLAUDE.md]"*, and CLAUDE.md calls itself the single source of truth for operational rules. Having the enforceable detail only in the file that defers to the other one inverts that relationship.

## Verified as still exact in the same pass — unchanged

| Claim | Measured |
|---|---|
| Type list in CLAUDE.md and CONTRIBUTING.md | byte-identical to `TYPES` in `check-commit-msg.sh` |
| Exemption prose in both docs | matches the script's four branches after #417 anchored them |
| `6 vulnerabilities (3 low, 2 moderate, 1 high)` | `npm audit` |
| `Vitest (1228 tests) + Django unittest (355 tests)` | both suites |
| CLAUDE.md size figure | was exact at 33.9 before this edit |

The size figure is now `34.1 KB / 184 lines` — re-measured after these edits, which invalidated the old value, and re-checked after prettier ran on commit. Worth naming the tension: CLAUDE.md's own note says it is over the 25 KB target and the lever is compressing wording in place, so both additions were kept to one clause each rather than a new section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)